### PR TITLE
Adjust storage.go files for recent Storage package update

### DIFF
--- a/59_appengine-GCS-storage/02_NewWriter_JSON-auth/storage.go
+++ b/59_appengine-GCS-storage/02_NewWriter_JSON-auth/storage.go
@@ -21,8 +21,7 @@ func handlePut(res http.ResponseWriter, req *http.Request) {
 		http.Error(res, "ERROR CREATING NEW CLIENT: "+err.Error(), 500)
 		return
 	}
-	bucketHandle := client.Bucket(gcsBucket)
-	writer := bucketHandle.Object("myOffice.txt").NewWriter(ctx)
+	writer := client.Bucket(gcsBucket).Object("myOffice.txt").NewWriter(ctx)
 	writer.ContentType = "text/plain"
 	io.WriteString(writer, "in my office")
 	err = writer.Close()

--- a/59_appengine-GCS-storage/02_NewWriter_JSON-auth/storage.go
+++ b/59_appengine-GCS-storage/02_NewWriter_JSON-auth/storage.go
@@ -3,55 +3,26 @@ package storage
 import (
 	"io"
 	"net/http"
-
-	"golang.org/x/oauth2/google"
-
-	"golang.org/x/net/context"
-	"golang.org/x/oauth2/jwt"
 	"google.golang.org/appengine"
-	"google.golang.org/cloud"
 	"google.golang.org/cloud/storage"
-	"io/ioutil"
 )
 
 const gcsBucket = "learning-1130-bucket-01"
-const aeId = "learning-1130"
-
-var conf *jwt.Config
 
 func init() {
 	http.HandleFunc("/put", handlePut)
-
-	jsonKey, err := ioutil.ReadFile("gcs.xxjson")
-	if err != nil {
-		panic("Couldn't read json key")
-	}
-
-	conf, err = google.JWTConfigFromJSON(
-		jsonKey,
-		storage.ScopeFullControl,
-	)
-	if err != nil {
-		panic("Couldn't get *jwt.Config")
-	}
-
-}
-
-func getCloudContext(req *http.Request) (context.Context, error) {
-	ctx := appengine.NewContext(req)
-	hc := conf.Client(ctx)
-	return cloud.NewContext(aeId, hc), nil
 }
 
 func handlePut(res http.ResponseWriter, req *http.Request) {
 
-	cctx, err := getCloudContext(req)
+	ctx := appengine.NewContext(req)
+	client, err := storage.NewClient(ctx)
 	if err != nil {
-		http.Error(res, "ERROR GETTING CCTX: "+err.Error(), 500)
+		http.Error(res, "ERROR CREATING NEW CLIENT: "+err.Error(), 500)
 		return
 	}
-
-	writer := storage.NewWriter(cctx, gcsBucket, "myOffice.txt")
+	bucketHandle := client.Bucket(gcsBucket)
+	writer := bucketHandle.Object("myOffice.txt").NewWriter(ctx)
 	writer.ContentType = "text/plain"
 	io.WriteString(writer, "in my office")
 	err = writer.Close()
@@ -59,4 +30,5 @@ func handlePut(res http.ResponseWriter, req *http.Request) {
 		http.Error(res, "ERROR WRITING TO BUCKET: "+err.Error(), 500)
 		return
 	}
+	client.Close()
 }


### PR DESCRIPTION
The recent Storage package update made some backwards-incompatible
changes. This patch adjusts some GolangTraining examples to work
correctly with the new Storage package.

More details here:
https://github.com/GoogleCloudPlatform/gcloud-golang/wiki/Storage-Package-Update