### PR TITLE
WordEn list doesn't exists (Map, hash table)

### DIFF
--- a/19_map/14_hash-table/04_english-alphabet/01/main.go
+++ b/19_map/14_hash-table/04_english-alphabet/01/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://www-01.sil.org/linguistics/wordlists/english/wordlist/wordsEn.txt")
+	res, err := http.Get("https://raw.githubusercontent.com/dwyl/english-words/master/words.txt")
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
The list could be changed by this one extracted from https://github.com/dwyl/english-words