### PR TITLE
Fix reference to 'method' variable in closure

### DIFF
--- a/27_code-in-process/42_HTTP/02_http-server/i05_not-writing_error-in-code/main.go
+++ b/27_code-in-process/42_HTTP/02_http-server/i05_not-writing_error-in-code/main.go
@@ -22,7 +22,7 @@ func handleConn(conn net.Conn) {
 
 		if i == 0 {
 			fs := strings.Fields(ln)
-			method := fs[0]
+			method = fs[0]
 			url = fs[1]
 			fmt.Println("METHOD", method)
 			fmt.Println("URL", url)


### PR DESCRIPTION
It cannot be stored in the method variable defined in L18 because the value is assigned to method as a local variable In L25. Shadowed.

Fix by referring to the closure.