### PR TITLE
fixed typo in word Inheritance

### DIFF
--- a/20_struct/00_object-oriented/notes.txt
+++ b/20_struct/00_object-oriented/notes.txt
@@ -6,7 +6,7 @@ behavior ("methods")
 exported / un-exported
 
 (2) Reusability
-inheritence ("embedded types")
+inheritance ("embedded types")
 
 (3) Polymorphism
 interfaces
@@ -25,7 +25,7 @@ Classes
 ==== behavior / methods
 -- public / private
 
-Inheritence
+Inheritance
 
 //////////////
 In Go:


### PR DESCRIPTION
fixed typo in word "Inheritance" which was written as "Inheritence".
However, embedded types in Go are rather works as composition, not inheritance.